### PR TITLE
Fixes #33: Write the correct command line tool

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const checkFiles = async data => {
 	const usage = await getFile(addExtensions(['usage'], ['sh', 'bash']))
 	const screenshotFiles = addExtensions(['screenshot'], ['png', 'jpg', 'gif'])
 	const screenshot = await getFile(addPaths(['media', ''], screenshotFiles))
-	const yarn = await getFile(addExtensions(['yarn'] ,['lock']))
+	const yarn = await getFile(addExtensions(['yarn'], ['lock']))
 
 	if (documentation) {
 		data.documentation = documentation

--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ const checkFiles = async data => {
 	const usage = await getFile(addExtensions(['usage'], ['sh', 'bash']))
 	const screenshotFiles = addExtensions(['screenshot'], ['png', 'jpg', 'gif'])
 	const screenshot = await getFile(addPaths(['media', ''], screenshotFiles))
+	const yarn = await getFile(addExtensions(['yarn'] ,['lock']))
 
 	if (documentation) {
 		data.documentation = documentation
@@ -143,6 +144,10 @@ const checkFiles = async data => {
 
 	if (screenshot) {
 		data.screenshot = path.posix.relative(cwd, screenshot)
+	}
+
+	if (yarn) {
+		data.yarn = true
 	}
 
 	return data
@@ -342,6 +347,7 @@ const main = async () => {
 		documentation: false,
 		travis: false,
 		atom: false,
+		yarn: false,
 		write: false,
 		xo: false,
 		engines: {}

--- a/template.md
+++ b/template.md
@@ -14,7 +14,7 @@
 
 ## Installation
 
-Module available through the [npm registry](https://www.npmjs.com/). It can be installed using the {{#atom}}[`apm`](https://github.com/atom/apm){{/atom}} {{^atom}}[`npm`](https://docs.npmjs.com/getting-started/installing-npm-packages-locally) or [`yarn`](https://yarnpkg.com/en/){{/atom}} command line tools.
+Module available through the [npm registry](https://www.npmjs.com/). It can be installed using the {{#atom}}[`apm`](https://github.com/atom/apm){{/atom}}{{^atom}}{{^yarn}}[`npm`](https://docs.npmjs.com/getting-started/installing-npm-packages-locally){{/yarn}}{{#yarn}}[`yarn`](https://yarnpkg.com/en/){{/yarn}}{{/atom}} command line tool.
 
 ```sh
 {{#atom}}
@@ -66,12 +66,18 @@ yarn add {{name}}
 
 To run the test suite, first install the dependencies, then run `test`:
 
+{{^@root.yarn}}
 ```sh
 # NPM
 npm test
-# Or Using Yarn
+```
+{{/@root.yarn}}
+{{#@root.yarn}}
+```sh
+# Using Yarn
 yarn test
 ```
+{{/yarn}}
 {{/scripts.test}}
 
 ## Dependencies


### PR DESCRIPTION
Changes to use the correct package manager (npm/yarn) based on the presence of lock file